### PR TITLE
Acid explosion bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/__pycache__
 **/.vscode
 **/discord.log
+./notes

--- a/utility/cog/character/ability/effect/debuff/acid_explosion.py
+++ b/utility/cog/character/ability/effect/debuff/acid_explosion.py
@@ -35,7 +35,7 @@ class Debuff_acid_explosion(Effect):
 
         # info
         self.name = "Acid explosion"
-        self.icon = self.icon['effect']['acid_explosion']
+        self.icon = self.game_icon['effect']['acid_explosion']
         self.id = 3
 
         # duration


### PR DESCRIPTION
Fixed a reference in the acid_explosion code that was the cause of the dbtrain command crash