### PR TITLE
add `cancel fight` command

### DIFF
--- a/cog/command/cancel.py
+++ b/cog/command/cancel.py
@@ -1,0 +1,58 @@
+"""
+Allow the player to cancel an action
+
+--
+
+Author : DrLarck
+
+Last update : 31/01/20 (DrLarck)
+"""
+
+# dependancies
+import asyncio
+from discord.ext import commands
+
+# util
+from utility.cog.player.player import Player
+
+# checker
+from utility.command.checker.basic import Basic_checker
+from utility.command.checker.fight import Fight_checker
+
+# command
+class Cmd_cancel(commands.Cog):
+
+    def __init__(self, client):
+        self.client = client
+
+    @commands.check(Basic_checker().is_game_ready)
+    @commands.check(Basic_checker().is_registered)
+    @commands.group(invoke_without_command = False)
+    async def cancel(self, ctx):
+        """
+        Allow the player to cancel an action
+        """
+
+        return
+    
+    @cancel.command()
+    async def fight(self, ctx):
+        """
+        Allow the player to reset its `in_fight` status
+        """
+
+        # init
+        player = Player(ctx, self.client, ctx.message.author)
+        checker = Fight_checker()
+
+        # check if the player is in a fight
+        if player.id in checker.in_fight:
+            checker.in_fight.remove(player.id)
+
+            await ctx.send("You are no longer in a fight.")
+        
+        else:
+            await ctx.send("You're not in a fight.")
+
+def setup(client):
+    client.add_cog(Cmd_cancel(client))

--- a/utility/cog/cog_loader.py
+++ b/utility/cog/cog_loader.py
@@ -5,7 +5,7 @@ Load the cogs.
 
 Author : DrLarck
 
-Last update : 04/01/2020 (DrLarck)
+Last update : 31/01/2020 (DrLarck)
 """
 
 # dependancies
@@ -38,7 +38,7 @@ class Cog_loader:
             "cog.command.help",
             "cog.command.train", "cog.command.summon", "cog.command.box",
             "cog.command.start", "cog.command.fighter", "cog.command.show",
-            "cog.command.profile",
+            "cog.command.profile", "cog.command.cancel",
             # other
             "cog.event.on_event"
         ]

--- a/utility/cog/fight_system/fight.py
+++ b/utility/cog/fight_system/fight.py
@@ -5,7 +5,7 @@ The :class:`Fight()` manages a fight, from the beginning to the end and returns 
 
 Author : DrLarck
 
-Last update : 25/12/19 (DrLarck)
+Last update : 31/01/20 (DrLarck)
 """
 
 # dependancies
@@ -165,7 +165,8 @@ class Fight:
 
         # init
         # add the caller's id in the list of player that are already fighting
-        Fight_checker.in_fight.append(self.player.id)
+        checker = Fight_checker()
+        checker.in_fight.append(self.player.id)
 
             # translation
         translation = Translator(self.client.db, self.player)
@@ -220,9 +221,17 @@ class Fight:
             self.battle_phae = Battle_phase(self.client, self.ctx, self.player, None)
 
             # new turn
+
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             await self.ctx.send(f"```########## 📣 Round {turn} ! ##########```")
             await asyncio.sleep(2)
+
             # team displaying
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             if(turn == 1):
                 await self.ctx.send("```👥 Teams```")
                 await asyncio.sleep(1)
@@ -233,6 +242,9 @@ class Fight:
             await asyncio.sleep(1)
 
             # get move
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
                 # team a
             team_a_move = await self.selection_phase.start_selection(0, team)
                 # check if the player want to flee
@@ -245,6 +257,9 @@ class Fight:
             team_b_move = await self.selection_phase.start_selection(1, team)
 
             # battle phase
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             await self.ctx.send(f"```⚔ - Battle phase```")
             await asyncio.sleep(2)
 
@@ -258,6 +273,9 @@ class Fight:
             await self.reset_stat(team_b_ref)
 
             # trigger phase
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             await self.ctx.send("```🌀 - Trigger phase```")
             await asyncio.sleep(1)
 
@@ -269,11 +287,17 @@ class Fight:
             self.trigger_phase = Trigger_phase(team[0], team[1], turn)
 
                 # leader
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             if(turn == 1):
                 await self.ctx.send("```👑 - Leader skills```")
             await self.trigger_phase.trigger_leader(self.client, self.ctx, team[0][0])
 
                 # passive
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             if(turn == 1):
                 await self.ctx.send("```🏵 - Passive skills```")
             for character_a_ in team[0]:
@@ -282,6 +306,9 @@ class Fight:
                 await self.trigger_phase.trigger_passive(self.client, self.ctx, character_a_)
 
                 # effect
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             await self.ctx.send("```🌀 - Effects```")
             for character_a in team[0]:
                 await asyncio.sleep(0)
@@ -296,11 +323,17 @@ class Fight:
             self.trigger_phase = Trigger_phase(team[1], team[0], turn)
 
                 # leader
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             if(turn == 1):
                 await self.ctx.send("```👑 - Leader skills```")
             await self.trigger_phase.trigger_leader(self.client, self.ctx, team[1][0])
 
                 # passive
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             if(turn == 1):
                 await self.ctx.send("```🏵 - Passive skills```")            
             for character_b_ in team[1]:
@@ -309,6 +342,9 @@ class Fight:
                 await self.trigger_phase.trigger_passive(self.client, self.ctx, character_b_)
 
                 # effect
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
             await self.ctx.send("```🌀 - Effects```")
             for character_b in team[1]:
                 await asyncio.sleep(0)
@@ -318,6 +354,9 @@ class Fight:
                 character_index += 1
             
             # end of turn
+            if not await checker.is_fighting(self.ctx):  # if the player is no longer fighting
+                return
+
                 # calculate average hps
             team_a_average_hp, team_b_average_hp = await self.get_teams_hp(team)
 

--- a/utility/command/checker/fight.py
+++ b/utility/command/checker/fight.py
@@ -5,7 +5,7 @@ Regroups the fight checker
 
 Author : DrLarck
 
-Last update : 22/09/19 (DrLarck)
+Last update : 31/01/20 (DrLarck)
 """
 
 # dependancies
@@ -45,6 +45,27 @@ class Fight_checker:
             await ctx.send(f"<@{player.id}> ❌ You are already in a fight.")
 
         return(can_fight)
+    
+    async def is_fighting(self, ctx):
+        """
+        `coroutine`
+
+        This function checks if the player is still fighting or not.
+
+        This one is used to check if the continue has to be stoped if the player has quit using the `cancel fight` command.
+
+        --
+
+        Return : bool
+        """
+
+        # init
+        player = ctx.message.author
+
+        if player.id in self.in_fight:
+            return(True)
+            
+        return(False)
 
     async def has_team(self, ctx):
         """

--- a/utility/command/checker/fight.py
+++ b/utility/command/checker/fight.py
@@ -64,7 +64,7 @@ class Fight_checker:
 
         if player.id in self.in_fight:
             return(True)
-            
+        
         return(False)
 
     async def has_team(self, ctx):


### PR DESCRIPTION
This patch adds :

- The `cancel` **command group** 
- The `cancel fight` command which removes the player from the `in_fight` list
- The `.is_fighting()` method to the `Fight_checker()` checker to check if a player is currently in a fight or if he has left it using the `cancel` command
- Some `.is_fighting()` check during a combat to end it if the player had quit

## Side note
The `cancel` command group will be used to cancel the player's actions in case of problem.